### PR TITLE
added service-account impersonation

### DIFF
--- a/apis/v1alpha3/provider_types.go
+++ b/apis/v1alpha3/provider_types.go
@@ -26,10 +26,12 @@ import (
 type ProviderSpec struct {
 	// CredentialsSecretRef references a specific secret's key that contains
 	// the credentials that are used to connect to the GCP API.
-	CredentialsSecretRef xpv1.SecretKeySelector `json:"credentialsSecretRef"`
+	CredentialsSecretRef xpv1.SecretKeySelector `json:"credentialsSecretRef,omitempty"`
 
 	// ProjectID is the project name (not numerical ID) of this GCP Provider.
 	ProjectID string `json:"projectID"`
+	// ImpersonateServiceAccount is the GCP service account to impersonate instead of providing service account keys.
+	ImpersonateServiceAccount string `json:"impersonateServiceAccount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/v1beta1/providerconfig_types.go
+++ b/apis/v1beta1/providerconfig_types.go
@@ -35,9 +35,11 @@ type ProviderConfigSpec struct {
 type ProviderCredentials struct {
 	// Source of the provider credentials.
 	// +kubebuilder:validation:Enum=None;Secret;Environment;Filesystem
-	Source xpv1.CredentialsSource `json:"source"`
+	Source xpv1.CredentialsSource `json:"source,omitempty"`
 
 	xpv1.CommonCredentialSelectors `json:",inline"`
+	// ImpersonateServiceAccount is the GCP service account to impersonate instead of providing service account keys
+	ImpersonateServiceAccount string `json:"impersonateServiceAccount,omitempty"`
 }
 
 // A ProviderConfigStatus represents the status of a ProviderConfig.

--- a/package/crds/gcp.crossplane.io_providerconfigs.yaml
+++ b/package/crds/gcp.crossplane.io_providerconfigs.yaml
@@ -73,6 +73,10 @@ spec:
                     required:
                     - path
                     type: object
+                  impersonateServiceAccount:
+                    description: ImpersonateServiceAccount is the GCP service account
+                      to impersonate instead of providing service account keys
+                    type: string
                   secretRef:
                     description: A SecretRef is a reference to a secret key that contains
                       the credentials that must be used to connect to the provider.
@@ -99,8 +103,6 @@ spec:
                     - Environment
                     - Filesystem
                     type: string
-                required:
-                - source
                 type: object
               projectID:
                 description: ProjectID is the project name (not numerical ID) of this

--- a/package/crds/gcp.crossplane.io_providers.yaml
+++ b/package/crds/gcp.crossplane.io_providers.yaml
@@ -69,12 +69,15 @@ spec:
                 - name
                 - namespace
                 type: object
+              impersonateServiceAccount:
+                description: ImpersonateServiceAccount is the GCP service account
+                  to impersonate instead of providing service account keys.
+                type: string
               projectID:
                 description: ProjectID is the project name (not numerical ID) of this
                   GCP Provider.
                 type: string
             required:
-            - credentialsSecretRef
             - projectID
             type: object
         required:

--- a/pkg/clients/gcp.go
+++ b/pkg/clients/gcp.go
@@ -61,6 +61,10 @@ func UseProvider(ctx context.Context, c client.Client, mg resource.Managed) (pro
 		return "", nil, err
 	}
 
+	if account := p.Spec.ImpersonateServiceAccount; account != "" {
+		return p.Spec.ProjectID, option.ImpersonateCredentials(account), nil
+	}
+
 	ref := p.Spec.CredentialsSecretRef
 	s := &v1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}, s); err != nil {
@@ -78,6 +82,9 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 	}
 	if err := c.Get(ctx, types.NamespacedName{Name: mg.GetProviderConfigReference().Name}, pc); err != nil {
 		return "", nil, err
+	}
+	if account := pc.Spec.Credentials.ImpersonateServiceAccount; account != "" {
+		return pc.Spec.ProjectID, option.ImpersonateCredentials(account), nil
 	}
 	data, err := resource.CommonCredentialExtractor(ctx, pc.Spec.Credentials.Source, c, pc.Spec.Credentials.CommonCredentialSelectors)
 	if err != nil {


### PR DESCRIPTION
### Description of your changes
Include the options to use service account impersonation instead of providing a service account key. This would be helpful in environments where creating service account keys is prohibited.
Fixes #319

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested with a local default application key which was a k8s secret that the google application default environment variable used for its value in the controller. This key's account was given Service Token Creator role on the impersonated account. This impersonated account was specified in the ProviderConfigRef resource and was successful in creating a bucket. In a real GKE cluster, a workload identity service account would be attached to the controller.
[contribution process]: https://git.io/fj2m9
