### PR TITLE
Added Ability to use Access Tokens

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -36,11 +36,12 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	"github.com/crossplane-contrib/provider-gcp/apis"
 	scv1alpha1 "github.com/crossplane-contrib/provider-gcp/apis/v1alpha1"
 	gcp "github.com/crossplane-contrib/provider-gcp/pkg/controller"
 	"github.com/crossplane-contrib/provider-gcp/pkg/features"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -40,6 +40,7 @@ import (
 	scv1alpha1 "github.com/crossplane-contrib/provider-gcp/apis/v1alpha1"
 	gcp "github.com/crossplane-contrib/provider-gcp/pkg/controller"
 	"github.com/crossplane-contrib/provider-gcp/pkg/features"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
 func main() {

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -194,9 +194,9 @@ can smoothly set it up:
 ```console
 $ PROJECT_ID=<YOUR_GCP_PROJECT_ID>                               # e.g.) acme-prod
 $ GCP_SERVICE_ACCOUNT=<YOUR_CROSSPLANE_GCP_SERVICE_ACCOUNT_NAME> # e.g.) crossplane
-$ ROLE=<YOUR_ROLE_FOR_CROSSPLANE_GCP_SERVICE_ACCOUNT>            # e.g.) roles/cloudsql.admin
+$ ROLE=<YOUR_ROLE_FOR_CROSSPLANE_GCP_SERVICE_ACCOUNT>            # e.g.) roles/editor
 $ KUBERNETES_SERVICE_ACCOUNT=<YOUR_KUBERNETES_SERVICE_ACCOUNT>   # e.g.) token-generator
-$ NAMESPACE=<YOUR_KUBERNETES_NAMESPACE>                          # e.g.) mynamespace
+$ NAMESPACE=<YOUR_KUBERNETES_NAMESPACE>                          # e.g.) default
 $ SECRET_NAME=<YOUR_CREDENTIALS_SECRET_NAME>                     # e.g.) gcp-credentials
 $ SECRET_KEY=<NAME_OF_KEY_IN_SECRET>                             # e.g.) token
 ```

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -177,3 +177,168 @@ EOF
 
 Now that you have configured `provider-gcp` with Workload Identity supported,
 you can [provision infrastructure](https://crossplane.io/docs/v1.6/getting-started/provision-infrastructure).
+
+
+## Authenticating with Access Tokens
+
+Using temporary Access Tokens will require a process to regenerate an access token before it expires. Luckily we can use a Kubernetes CronJob to fulfill that.
+
+### Steps
+
+#### 0. Prepare your variables
+
+In the following sections, you'll need to name your resources.
+Define the variables below with any names valid in Kubernetes or GCP so that you
+can smoothly set it up:
+
+```console
+$ PROJECT_ID=<YOUR_GCP_PROJECT_ID>                               # e.g.) acme-prod
+$ GCP_SERVICE_ACCOUNT=<YOUR_CROSSPLANE_GCP_SERVICE_ACCOUNT_NAME> # e.g.) crossplane
+$ ROLE=<YOUR_ROLE_FOR_CROSSPLANE_GCP_SERVICE_ACCOUNT>            # e.g.) roles/cloudsql.admin
+$ KUBERNETES_SERVICE_ACCOUNT=<YOUR_KUBERNETES_SERVICE_ACCOUNT>   # e.g.) token-generator
+$ NAMESPACE=<YOUR_KUBERNETES_NAMESPACE>                          # e.g.) mynamespace
+$ SECRET_NAME=<YOUR_CREDENTIALS_SECRET_NAME>                     # e.g.) gcp-credentials
+$ SECRET_KEY=<NAME_OF_KEY_IN_SECRET>                             # e.g.) token
+```
+
+#### 1. Configure service accounts to use Workload Identity
+
+Create a GCP service account, which will be used for provisioning actual
+infrastructure in GCP, and grant IAM roles you need for accessing the Google
+Cloud APIs:
+
+```console
+$ gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT} --project ${PROJECT_ID}
+$ gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+    --member "serviceAccount:${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com" \
+    --role ${ROLE} \
+    --project ${PROJECT_ID}
+```
+
+#### 2. Create resources to generate an access-token
+Create the Kubernetes service account, RBAC, and CronJob to generate the temporary access-token
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name:  ${KUBERNETES_SERVICE_ACCOUNT}
+  namespace: ${NAMESPACE}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${KUBERNETES_SERVICE_ACCOUNT}-sync
+rules:
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs:
+  - get
+  - create
+  - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: ${KUBERNETES_SERVICE_ACCOUNT}-sync-rb
+subjects:
+- kind: ServiceAccount
+  name: ${KUBERNETES_SERVICE_ACCOUNT}
+roleRef:
+  kind: Role
+  name: ${KUBERNETES_SERVICE_ACCOUNT}-sync
+  apiGroup: ""
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ${KUBERNETES_SERVICE_ACCOUNT}-credentials-sync
+spec:
+  suspend: false
+  schedule: "*/45 * * * *"
+  failedJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  startingDeadlineSeconds: 1800
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName:  ${KUBERNETES_SERVICE_ACCOUNT}
+          restartPolicy: Never
+          containers:
+            - image: google/cloud-sdk:debian_component_based
+              name: create-access-token
+              imagePullPolicy: IfNotPresent
+              livenessProbe:
+                exec:
+                  command:
+                  - gcloud
+                  - version
+              readinessProbe:
+                exec:
+                  command:
+                  - gcloud
+                  - version
+              env:
+                - name: SECRET_NAME
+                  value: ${SECRET_NAME}
+                - name: SECRET_KEY
+                  value: ${SECRET_KEY}
+              command:
+                - /bin/bash
+                - -ce
+                - |-
+                  kubectl create secret generic $SECRET_NAME \
+                    --dry-run=client \
+                    --from-literal=$SECRET_KEY=$(gcloud auth print-access-token) \
+                    -o yaml | kubectl apply -f -
+              resources:
+                requests:
+                  cpu: 250m
+                  memory: 256Mi
+                limits:
+                  cpu: 500m
+                  memory: 512Mi
+EOF
+```
+Grant `roles/iam.workloadIdentityUser` to the GCP service account:
+
+```console
+$ gcloud iam service-accounts add-iam-policy-binding \
+    ${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+    --role roles/iam.workloadIdentityUser \
+    --member "serviceAccount:${PROJECT_ID}.svc.id.goog[${NAMESPACE}/${KUBERNETES_SERVICE_ACCOUNT}]" \
+    --project ${PROJECT_ID}
+```
+
+Annotate the `ServiceAccount` with the email address of the GCP service account:
+
+```console
+$ kubectl annotate serviceaccount ${KUBERNETES_SERVICE_ACCOUNT} \
+    iam.gke.io/gcp-service-account=${GCP_SERVICE_ACCOUNT}@${PROJECT_ID}.iam.gserviceaccount.com \
+    -n ${NAMESPACE}
+```
+
+#### 3. Create initial Access Token
+```console
+kubectl create job --from=cronjob/${KUBERNETES_SERVICE_ACCOUNT}-credentials-sync cred-sync-001
+```
+
+#### 4. Create ProviderConfig
+```console
+$ cat <<EOF | kubectl apply -f -
+apiVersion: gcp.crossplane.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  projectID: ${PROJECT_ID}
+  credentials:
+    source: Secret
+    secretRef:
+      name: ${SECRET_NAME}
+      namespace: ${NAMESPACE}
+      key: ${SECRET_KEY}
+EOF

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -183,6 +183,10 @@ you can [provision infrastructure](https://crossplane.io/docs/v1.6/getting-start
 
 Using temporary Access Tokens will require a process to regenerate an access token before it expires. Luckily we can use a Kubernetes CronJob to fulfill that.
 
+**DISCLAIMER**
+
+*The following method will only work if running the provider in a GKE cluster on GCP. This is because the creation of access tokens requires a service account with Workload Identity enabled.*
+
 ### Steps
 
 #### 0. Prepare your variables

--- a/pkg/clients/gcp.go
+++ b/pkg/clients/gcp.go
@@ -110,16 +110,15 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 		}
 		if isJSON(data) {
 			return pc.Spec.ProjectID, option.WithCredentialsJSON(data), nil
-		} else {
-			t := oauth2.Token{
-				AccessToken: string(data),
-			}
-			if ok := t.Valid(); !ok {
-				return pc.Spec.ProjectID, opts, errors.New("Access token invalid")
-			}
-			ts := oauth2.StaticTokenSource(&t)
-			return pc.Spec.ProjectID, option.WithTokenSource(ts), nil
 		}
+		t := oauth2.Token{
+			AccessToken: string(data),
+		}
+		if ok := t.Valid(); !ok {
+			return pc.Spec.ProjectID, opts, errors.New("Access token invalid")
+		}
+		ts := oauth2.StaticTokenSource(&t)
+		return pc.Spec.ProjectID, option.WithTokenSource(ts), nil
 	}
 }
 

--- a/pkg/clients/gcp.go
+++ b/pkg/clients/gcp.go
@@ -110,16 +110,17 @@ func UseProviderConfig(ctx context.Context, c client.Client, mg resource.Managed
 		}
 		if isJSON(data) {
 			opts = append(opts, option.WithCredentialsJSON(data))
-		} else {
-			t := oauth2.Token{
-				AccessToken: string(data),
-			}
-			if ok := t.Valid(); !ok {
-				return pc.Spec.ProjectID, opts, errors.New("Access token invalid")
-			}
-			ts := oauth2.StaticTokenSource(&t)
-			opts = append(opts, option.WithTokenSource(ts))
+			return pc.Spec.ProjectID, opts, nil
 		}
+		t := oauth2.Token{
+			AccessToken: string(data),
+		}
+		if ok := t.Valid(); !ok {
+			return pc.Spec.ProjectID, opts, errors.New("Access token invalid")
+		}
+		ts := oauth2.StaticTokenSource(&t)
+		opts = append(opts, option.WithTokenSource(ts))
+
 	}
 	return pc.Spec.ProjectID, opts, nil
 }


### PR DESCRIPTION
Signed-off-by: Brad Wadsworth <brad.wadsworth@mavenwave.com>

### Description of your changes
This change will read the secret key in a Kubernetes secret and if it is not in a JSON format, it will treat it as a Access Token. The documentation has also been updated to demonstrate how a CronJob resource can keep the Access Token up to date 
Fixes #460 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested the change in a Kind cluster using the update `docs/AUTHENTICATION.md`.

[contribution process]: https://git.io/fj2m9
