### PR TITLE
Readme: fix bad URL (404 error)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ adds the following new functionality:
 ## Getting Started and Documentation
 
 For getting started guides, installation, deployment, and administration, see
-our [Documentation](https://crossplane.io/docs/latest).
+our [Documentation](https://crossplane.io/docs).
 
 ## Contributing
 


### PR DESCRIPTION
In the Readme, the URL returning the documentation was bad. I propose **https://crossplane.io/docs/**

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Not necessary.

