### PR TITLE
Update OWNERS.md to remove Upbound maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -10,11 +10,5 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 ## Maintainers
 
-* Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
-* Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))
-* Muvaffak Onuş <monus@upbound.io> ([muvaf](https://github.com/muvaf))
-* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
-* Hasan Türken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
-* Alper Rifat Uluçınar <alper@upbound.io> ([ulucinar](https://github.com/ulucinar))
-* Aaron Eaton <aaron@upbound.io>  ([AaronME](https://github.com/AaronME))
+* Daniel Mangum <georgedanielmangum@gmail.com> ([hasheddan](https://github.com/hasheddan))
 * Gabriel Ferreira <gabidferreira9@gmail.com> ([Feggah](https://github.com/Feggah))


### PR DESCRIPTION
### Description of your changes

This update removes the maintainers from Upbound. At Upbound, we have switched to our own GCP provider, https://github.com/upbound/provider-gcp. Due to the focus on maintaining and improving Upbound's GCP provider, we no longer plan to contribute any further updates to this provider. As such, we want to ensure we don't send the wrong signal that the community should rely on Upbound to maintain this provider. 

We encourage community members interested in stepping up to maintain this provider to reach out to the remaining project maintainers to partner with them.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
