### PR TITLE
Add myself as maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -12,3 +12,4 @@ guidelines and responsibilities for the steering committee and maintainers.
 
 * Daniel Mangum <georgedanielmangum@gmail.com> ([hasheddan](https://github.com/hasheddan))
 * Gabriel Ferreira <gabidferreira9@gmail.com> ([Feggah](https://github.com/Feggah))
+* Dan Small <d.small@sap.com> ([dee0sap](https://github.com/dee0sap))


### PR DESCRIPTION
### Description of your changes

Adding myself as a maintainer as my team is using this provider and we want to make sure it is maintained for as long as we continue to do so.   Doing this in light of the recent announcement that Upbound dev's will no longer contribute to the community providers.

This search 
https://github.com/search?q=+commenter%3Adee0++commenter%3Adee0sap+org%3Acrossplane+org%3Akubernetes+org%3Akubernetes-sigs+org%3Acrossplane-contrib+&type=issues
shows my contributions to the community within github as of 2023-08-29.    I suppose the most significant contributions in github are the PR and the assistance in resolving provider-aws issue [802](https://github.com/crossplane-contrib/provider-aws/issues/802).

This is me on linkedin
https://www.linkedin.com/in/dansmallproblemsolver/
.  Have been with SAP for a few years now and am  on a team that hopes to continue using Crossplane for a long time.   So of course we're have an interest in it being maintained.

Fixes #

NA

I have:

- [X ] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

NA