### PR TITLE
fix subnetwork SecondaryIpRanges update issue

### DIFF
--- a/pkg/clients/subnetwork/subnetwork.go
+++ b/pkg/clients/subnetwork/subnetwork.go
@@ -124,6 +124,9 @@ func IsUpToDate(name string, in *v1beta1.SubnetworkParameters, observed *compute
 	if !ok {
 		return true, false, errors.New(errCheckUpToDate)
 	}
+	// empty the SecondaryIpRanges to ensure that SecondaryRanges will be deleted
+	// when the user removes them from the CR.
+	desired.SecondaryIpRanges = make([]*compute.SubnetworkSecondaryRange, 0)
 	GenerateSubnetwork(name, *in, desired)
 	if !cmp.Equal(desired.PrivateIpGoogleAccess, observed.PrivateIpGoogleAccess) {
 		return false, true, nil

--- a/pkg/clients/subnetwork/subnetwork_test.go
+++ b/pkg/clients/subnetwork/subnetwork_test.go
@@ -72,6 +72,10 @@ func params(m ...func(*v1beta1.SubnetworkParameters)) *v1beta1.SubnetworkParamet
 	return o
 }
 
+func removeSecondaryRanges(s *v1beta1.SubnetworkParameters) {
+	s.SecondaryIPRanges = nil
+}
+
 func subnetwork(m ...func(*compute.Subnetwork)) *compute.Subnetwork {
 	o := &compute.Subnetwork{
 		Description:           testDescription,
@@ -291,6 +295,17 @@ func TestIsUpToDate(t *testing.T) {
 				}),
 			},
 			want: want{upToDate: false, privAcc: true},
+		},
+		"NotUpToDateSecondaryRanges": {
+			args: args{
+				name:    testName,
+				in:      params(removeSecondaryRanges),
+				current: subnetwork(),
+			},
+			want: want{
+				upToDate: false,
+				privAcc:  false,
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes subnetwork SecondaryIpRanges update issue:
When Subnetwork CR's `.spec.forProvider.SecondaryIPRanges` is deleted, the cloud resource isn't patched.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
